### PR TITLE
Fix error on import of external modules

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -40,5 +40,6 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",
-  "license": "MIT"
+  "license": "MIT",
+  "type": "module"
 }

--- a/server/simulator/engine/engine.ts
+++ b/server/simulator/engine/engine.ts
@@ -23,7 +23,7 @@ import { identity, pipe } from 'fp-ts/lib/function';
 import * as NEA from 'fp-ts/lib/NonEmptyArray';
 import LOGGER from "../../utils/logger";
 import { match, __, not, select, when } from 'ts-pattern';
-import { stringify } from "fp-ts/Json";
+import { stringify } from "fp-ts/lib/Json";
 
 function deepcopy<T>(obj: T): T {
     return v8.deserialize(v8.serialize(obj));

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -43,7 +43,7 @@
     // "noPropertyAccessFromIndexSignature": true,  /* Require undeclared properties from index signatures to use element accesses. */
 
     /* Module Resolution Options */
-    // "moduleResolution": "node",                  /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "moduleResolution": "node",                  /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
     // "baseUrl": "./",                             /* Base directory to resolve non-absolute module names. */
     // "paths": {},                                 /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */


### PR DESCRIPTION
There were import errors for the fp-ts package after the change in server/tsconfig.json from "module": "commonjs" to "module": "ESNext" in #78655b17.
The error basically asked that the changes in this commite were made in tsconfig.json (moduleResultion -> node) and in package.json("type": "module").
Also an import (fp-ts/Json) which worked with commonjs did not work now, so it was also fixed.